### PR TITLE
Remove unsound ScopedCoroutine

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,19 +172,27 @@ fn main() {
 ```text
    0: backtrace::main::{{closure}}
              at examples/backtrace.rs:11:21
-      corosensei::coroutine::ScopedCoroutine<Input,Yield,Return,Stack>::with_stack::coroutine_func::{{closure}}
-             at src/coroutine.rs:174:62
+      corosensei::coroutine::Coroutine<Input,Yield,Return,Stack>::with_stack::coroutine_func::{{closure}}
+             at src/coroutine.rs:163:62
+      <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
+             at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/core/src/panic/unwind_safe.rs:272:9
+      std::panicking::try::do_call
+             at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/std/src/panicking.rs:559:40
+      std::panicking::try
+             at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/std/src/panicking.rs:523:19
+   1: std::panic::catch_unwind
+             at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/std/src/panic.rs:149:14
       corosensei::unwind::catch_unwind_at_root
-             at src/unwind.rs:43:16
-   1: corosensei::coroutine::ScopedCoroutine<Input,Yield,Return,Stack>::with_stack::coroutine_func
-             at src/coroutine.rs:174:30
+             at src/unwind.rs:227:13
+      corosensei::coroutine::Coroutine<Input,Yield,Return,Stack>::with_stack::coroutine_func
+             at src/coroutine.rs:163:30
    2: stack_init_trampoline
    3: corosensei::arch::x86_64::switch_and_link
-             at src/arch/x86_64.rs:302:5
-      corosensei::coroutine::ScopedCoroutine<Input,Yield,Return,Stack>::resume_inner
-             at src/coroutine.rs:256:13
-      corosensei::coroutine::ScopedCoroutine<Input,Yield,Return,Stack>::resume
-             at src/coroutine.rs:235:19
+             at src/unwind.rs:137:17
+      corosensei::coroutine::Coroutine<Input,Yield,Return,Stack>::resume_inner
+             at src/coroutine.rs:239:13
+      corosensei::coroutine::Coroutine<Input,Yield,Return,Stack>::resume
+             at src/coroutine.rs:218:19
       backtrace::sub_function
              at examples/backtrace.rs:6:5
    4: backtrace::main

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,19 +165,27 @@
 //! ```text
 //!    0: backtrace::main::{{closure}}
 //!              at examples/backtrace.rs:11:21
-//!       corosensei::coroutine::ScopedCoroutine<Input,Yield,Return,Stack>::with_stack::coroutine_func::{{closure}}
-//!              at src/coroutine.rs:174:62
+//!       corosensei::coroutine::Coroutine<Input,Yield,Return,Stack>::with_stack::coroutine_func::{{closure}}
+//!              at src/coroutine.rs:163:62
+//!       <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
+//!              at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/core/src/panic/unwind_safe.rs:272:9
+//!       std::panicking::try::do_call
+//!              at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/std/src/panicking.rs:559:40
+//!       std::panicking::try
+//!              at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/std/src/panicking.rs:523:19
+//!    1: std::panic::catch_unwind
+//!              at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/std/src/panic.rs:149:14
 //!       corosensei::unwind::catch_unwind_at_root
-//!              at src/unwind.rs:43:16
-//!    1: corosensei::coroutine::ScopedCoroutine<Input,Yield,Return,Stack>::with_stack::coroutine_func
-//!              at src/coroutine.rs:174:30
+//!              at src/unwind.rs:227:13
+//!       corosensei::coroutine::Coroutine<Input,Yield,Return,Stack>::with_stack::coroutine_func
+//!              at src/coroutine.rs:163:30
 //!    2: stack_init_trampoline
 //!    3: corosensei::arch::x86_64::switch_and_link
-//!              at src/arch/x86_64.rs:302:5
-//!       corosensei::coroutine::ScopedCoroutine<Input,Yield,Return,Stack>::resume_inner
-//!              at src/coroutine.rs:256:13
-//!       corosensei::coroutine::ScopedCoroutine<Input,Yield,Return,Stack>::resume
-//!              at src/coroutine.rs:235:19
+//!              at src/unwind.rs:137:17
+//!       corosensei::coroutine::Coroutine<Input,Yield,Return,Stack>::resume_inner
+//!              at src/coroutine.rs:239:13
+//!       corosensei::coroutine::Coroutine<Input,Yield,Return,Stack>::resume
+//!              at src/coroutine.rs:218:19
 //!       backtrace::sub_function
 //!              at examples/backtrace.rs:6:5
 //!    4: backtrace::main
@@ -227,7 +235,7 @@
 //! Implies `unwind`.
 
 #![no_std]
-#![cfg_attr(feature = "asm-unwind", feature(asm_unwind, c_unwind, asm_sym))]
+#![cfg_attr(feature = "asm-unwind", feature(asm_unwind, c_unwind))]
 #![warn(missing_docs)]
 
 // Must come first because it defines macros used by other modules.

--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -15,11 +15,6 @@ cfg_if::cfg_if! {
     } else if #[cfg(all(feature = "default-stack", windows))] {
         mod windows;
         pub use self::windows::DefaultStack;
-    } else {
-        /// Dummy stack for platforms that do not provide a default stack.
-        ///
-        /// This is only here for use as a default generic parameter.
-        pub struct DefaultStack;
     }
 }
 

--- a/src/tests/coroutine.rs
+++ b/src/tests/coroutine.rs
@@ -1,12 +1,15 @@
+extern crate alloc;
 extern crate std;
 
+use core::sync::atomic::{AtomicBool, Ordering};
 use std::cell::Cell;
 use std::rc::Rc;
 use std::string::ToString;
 use std::{println, ptr};
 
-use crate::coroutine::Coroutine;
-use crate::{CoroutineResult, ScopedCoroutine};
+use alloc::sync::Arc;
+
+use crate::{Coroutine, CoroutineResult};
 
 #[test]
 fn smoke() {
@@ -95,7 +98,7 @@ fn panics_propagated() {
     let a = Rc::new(Cell::new(false));
     let b = SetOnDrop(a.clone());
     let mut coroutine = Coroutine::<(), (), ()>::new(move |_, ()| {
-        drop(&b);
+        drop(b);
         panic!("foobar");
     });
     let result = panic::catch_unwind(AssertUnwindSafe(|| coroutine.resume(())));
@@ -121,7 +124,7 @@ fn panics_propagated_via_parent() {
     let a = Rc::new(Cell::new(false));
     let b = SetOnDrop(a.clone());
     let mut coroutine = Coroutine::<(), (), ()>::new(move |y, ()| {
-        drop(&b);
+        drop(b);
         y.on_parent_stack(|| {
             panic!("foobar");
         });
@@ -156,6 +159,7 @@ fn suspend_and_resume_values() {
 
 #[test]
 fn stateful() {
+    #[allow(dead_code)]
     #[repr(align(128))]
     struct Aligned(u8);
     let state = [41, 42, 43, 44, 45];
@@ -174,18 +178,18 @@ fn stateful() {
 
 #[test]
 fn force_unwind() {
-    struct SetOnDrop<'a>(&'a mut bool);
-    impl<'a> Drop for SetOnDrop<'a> {
+    struct SetOnDrop(Arc<AtomicBool>);
+    impl Drop for SetOnDrop {
         fn drop(&mut self) {
-            *self.0 = true;
+            self.0.store(true, Ordering::Relaxed);
         }
     }
 
-    let mut a = false;
-    let mut b = false;
-    let a_drop = SetOnDrop(&mut a);
-    let b_drop = SetOnDrop(&mut b);
-    let mut coroutine = ScopedCoroutine::<(), (), (), _>::new(move |y, ()| {
+    let a = Arc::new(AtomicBool::new(false));
+    let b = Arc::new(AtomicBool::new(false));
+    let a_drop = SetOnDrop(a.clone());
+    let b_drop = SetOnDrop(b.clone());
+    let mut coroutine = Coroutine::<(), (), (), _>::new(move |y, ()| {
         drop(a_drop);
         y.suspend(());
         drop(b_drop);
@@ -196,16 +200,16 @@ fn force_unwind() {
     assert!(coroutine.started());
     assert!(coroutine.done());
     drop(coroutine);
-    assert!(a);
-    assert!(b);
+    assert!(a.load(Ordering::Relaxed));
+    assert!(b.load(Ordering::Relaxed));
 
     #[cfg(feature = "unwind")]
     {
-        let mut a = false;
-        let mut b = false;
-        let a_drop = SetOnDrop(&mut a);
-        let b_drop = SetOnDrop(&mut b);
-        let mut coroutine = ScopedCoroutine::<(), (), (), _>::new(move |y, ()| {
+        let a = Arc::new(AtomicBool::new(false));
+        let b = Arc::new(AtomicBool::new(false));
+        let a_drop = SetOnDrop(a.clone());
+        let b_drop = SetOnDrop(b.clone());
+        let mut coroutine = Coroutine::<(), (), (), _>::new(move |y, ()| {
             drop(a_drop);
             y.suspend(());
             drop(b_drop);
@@ -217,15 +221,15 @@ fn force_unwind() {
         assert!(coroutine.started());
         assert!(coroutine.done());
         drop(coroutine);
-        assert!(a);
-        assert!(b);
+        assert!(a.load(Ordering::Relaxed));
+        assert!(b.load(Ordering::Relaxed));
     }
 
-    let mut a = false;
-    let mut b = false;
-    let a_drop = SetOnDrop(&mut a);
-    let b_drop = SetOnDrop(&mut b);
-    let mut coroutine = ScopedCoroutine::<(), (), (), _>::new(move |y, ()| {
+    let a = Arc::new(AtomicBool::new(false));
+    let b = Arc::new(AtomicBool::new(false));
+    let a_drop = SetOnDrop(a.clone());
+    let b_drop = SetOnDrop(b.clone());
+    let mut coroutine = Coroutine::<(), (), (), _>::new(move |y, ()| {
         drop(a_drop);
         y.suspend(());
         drop(b_drop);
@@ -238,8 +242,8 @@ fn force_unwind() {
     assert!(coroutine.started());
     assert!(coroutine.done());
     drop(coroutine);
-    assert!(a);
-    assert!(b);
+    assert!(a.load(Ordering::Relaxed));
+    assert!(b.load(Ordering::Relaxed));
 }
 
 // The Windows stack starts out small with only one page comitted. Check that it

--- a/src/tests/on_stack.rs
+++ b/src/tests/on_stack.rs
@@ -59,7 +59,7 @@ fn panics_propagated() {
     let b = SetOnDrop(a.clone());
     let result = panic::catch_unwind(AssertUnwindSafe(move || {
         on_stack(DefaultStack::default(), move || {
-            drop(&b);
+            drop(b);
             panic!("foobar");
         })
     }));

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -1,4 +1,4 @@
-//! Utilities for working with [`ScopedCoroutine::trap_handler`].
+//! Utilities for working with [`Coroutine::trap_handler`].
 
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
@@ -7,7 +7,7 @@ pub use crate::arch::TrapHandlerRegs;
 use crate::stack::StackPointer;
 use crate::unwind::initial_func_abi;
 #[cfg(doc)]
-use crate::ScopedCoroutine; // For rustdoc to resolve doc-links
+use crate::Coroutine; // For rustdoc to resolve doc-links
 use crate::{arch, util};
 
 /// Helper type to force a trapping coroutine to return from a trap handler.
@@ -16,7 +16,7 @@ use crate::{arch, util};
 /// thread-local storage for access by a trap handler. However it is UB to call
 /// `setup_trap_return` past the lifetime of the originating coroutine.
 ///
-/// See [`ScopedCoroutine::trap_handler`] for more details.
+/// See [`Coroutine::trap_handler`] for more details.
 #[derive(Clone, Copy)]
 pub struct CoroutineTrapHandler<Return> {
     pub(crate) stack_base: StackPointer,


### PR DESCRIPTION
This is unsound because it allows values on the stack to be forgotten without running their associated drop code, which is unsound for constructs like scoped threads.

Fixes #27