### PR TITLE
deps: Update windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ scopeguard = { version = "1.1.0", default-features = false }
 libc = { version = "0.2.119", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.33.0", features = [
+windows-sys = { version = "0.59.0", features = [
     "Win32_Foundation",
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Kernel",


### PR DESCRIPTION
it's too old and it doesn't have support for `gnullvm` targets, which became a host for rustc on msys2/CLANG* environments recently 