### PR TITLE
Add support for sanitizers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ unwind = []
 # efficient but is only available on nightly Rust.
 asm-unwind = ["unwind"]
 
+# Support for running under sanitizers
+sanitizer = []
+
 # Build docs for all supported targets.
 [package.metadata.docs.rs]
 targets = [

--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ This crate currently supports the following targets:
 
 |             | ELF (Linux, BSD, bare metal, etc) | Darwin (macOS, iOS, etc) | Windows |
 | ----------- | --------------------------------- | ------------------------ | ------- |
-| x86_64      | ✅                                | ✅                       | ✅      |
-| x86         | ✅                                | ❌                       | ⚠️*      |
-| AArch64     | ✅                                | ✅                       | ❌      |
-| ARM         | ✅                                | ❌                       | ❌      |
-| RISC-V      | ✅                                | ❌                       | ❌      |
-| LoongArch64 | ✅                                | ❌                       | ❌      |
+| x86_64      | ✅                                 | ✅                        | ✅       |
+| x86         | ✅                                 | ❌                        | ⚠️*      |
+| AArch64     | ✅                                 | ✅                        | ❌       |
+| ARM         | ✅                                 | ❌                        | ❌       |
+| RISC-V      | ✅                                 | ❌                        | ❌       |
+| LoongArch64 | ✅                                 | ❌                        | ❌       |
 
 \* Linked backtraces are not supported on x86 Windows.
 
@@ -240,6 +240,14 @@ Requires `std`.
 This feature uses the `asm_unwind` nightly feature to allow panics to unwind directly through the inline assembly used in this crate, which can improve performance since it doesn't need to be passed across stack boundaries as a `Result`.
 
 Implies `unwind`.
+
+#### `sanitizer`
+
+This feature adds support for [sanitizers] like ASAN which helps detect bugs in unsafe code. Crates like `corosensei` which perform stack switching need to inform the sanitizer runtime of these stack switches to avoid false positive errors and/or crashes while running with sanitizers enabled.
+
+This feature should not be enabled when not running with sanitizers since it will result in linker errors due to the dependency on the sanitizer runtime API.
+
+[sanitizers]: https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html
 
 ## Performance
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -37,3 +37,9 @@ export RUST_TEST_THREADS=1
 #    "${CARGO}" test $CARGO_TEST_FLAGS --target "${TARGET}" --all-targets --features asm-unwind
 #    "${CARGO}" test $CARGO_TEST_FLAGS --target "${TARGET}" --all-targets --features asm-unwind --release
 #fi
+
+# Address sanitizer
+if [ "${CROSS}" = "0" && "${CHANNEL}" = "nightly" ]; then
+    TARGET_RUSTFLAGS=-Zsanitizer=address "${CARGO}" test $CARGO_TEST_FLAGS --target "${TARGET}" --all-targets --features sanitizer --tests
+    TARGET_RUSTFLAGS=-Zsanitizer=address "${CARGO}" test $CARGO_TEST_FLAGS --target "${TARGET}" --all-targets --features sanitizer --release --tests
+fi

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -73,6 +73,7 @@
 use core::arch::{asm, global_asm};
 
 use super::{allocate_obj_on_stack, push};
+use crate::coroutine::adjusted_stack_base;
 use crate::stack::{Stack, StackPointer};
 use crate::unwind::{
     asm_may_unwind_root, asm_may_unwind_yield, cfi_reset_args_size_root, cfi_reset_args_size_yield,
@@ -81,7 +82,8 @@ use crate::unwind::{
 use crate::util::EncodedValue;
 
 pub const STACK_ALIGNMENT: usize = 16;
-pub const PARENT_LINK_OFFSET: usize = 0;
+pub const PARENT_STACK_OFFSET: usize = 0;
+pub const PARENT_LINK_OFFSET: usize = 16;
 pub type StackWord = u64;
 
 global_asm!(
@@ -187,7 +189,7 @@ extern "C" {
 
 #[inline]
 pub unsafe fn init_stack<T>(stack: &impl Stack, func: InitialFunc<T>, obj: T) -> StackPointer {
-    let mut sp = stack.base().get();
+    let mut sp = adjusted_stack_base(stack).get();
 
     // Initial function.
     push(&mut sp, Some(func as StackWord));
@@ -498,7 +500,7 @@ pub unsafe fn setup_trap_trampoline<T>(
 ) -> TrapHandlerRegs {
     // Preserve the top 16 bytes of the stack since they contain the parent
     // link.
-    let parent_link = stack_base.get() - 16;
+    let parent_link = stack_base.get() - PARENT_LINK_OFFSET;
 
     // Everything below this can be overwritten. Write the object to the stack.
     let mut sp = parent_link;
@@ -531,7 +533,7 @@ pub unsafe fn on_stack(arg: *mut u8, stack: impl Stack, f: StackCallFunc) {
         concat!("bl ", asm_mangle!("stack_call_trampoline")),
         "nop",
         in("x0") arg,
-        in("x1") stack.base().get(),
+        in("x1") adjusted_stack_base(&stack).get(),
         in("x2") f,
         clobber_abi("C"),
     );

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -67,6 +67,7 @@
 use core::arch::{asm, global_asm};
 
 use super::{allocate_obj_on_stack, push};
+use crate::coroutine::adjusted_stack_base;
 use crate::stack::{Stack, StackPointer};
 use crate::unwind::{asm_may_unwind_root, InitialFunc, StackCallFunc, TrapHandler};
 use crate::util::EncodedValue;
@@ -242,7 +243,8 @@ cfg_if::cfg_if! {
 }
 
 pub const STACK_ALIGNMENT: usize = 8;
-pub const PARENT_LINK_OFFSET: usize = 0;
+pub const PARENT_STACK_OFFSET: usize = 0;
+pub const PARENT_LINK_OFFSET: usize = 8;
 pub type StackWord = u32;
 
 global_asm!(
@@ -405,7 +407,7 @@ extern "C" {
 
 #[inline]
 pub unsafe fn init_stack<T>(stack: &impl Stack, func: InitialFunc<T>, obj: T) -> StackPointer {
-    let mut sp = stack.base().get();
+    let mut sp = adjusted_stack_base(stack).get();
 
     // Initial function.
     push(&mut sp, Some(func as StackWord));
@@ -683,7 +685,7 @@ pub unsafe fn setup_trap_trampoline<T>(
     handler: TrapHandler<T>,
 ) -> TrapHandlerRegs {
     // Preserve the top 8 bytes of the stack since they contain the parent link.
-    let parent_link = stack_base.get() - 8;
+    let parent_link = stack_base.get() - PARENT_LINK_OFFSET;
 
     // Everything below this can be overwritten. Write the object to the stack.
     let mut sp = parent_link;
@@ -717,7 +719,7 @@ pub unsafe fn on_stack(arg: *mut u8, stack: impl Stack, f: StackCallFunc) {
         concat!("blx ", asm_mangle!("stack_call_trampoline")),
         "nop",
         in("r0") arg,
-        in("r1") stack.base().get(),
+        in("r1") adjusted_stack_base(&stack).get(),
         in("r2") f,
         clobber_abi("C"),
     )

--- a/src/arch/loongarch64.rs
+++ b/src/arch/loongarch64.rs
@@ -73,6 +73,7 @@
 use core::arch::{asm, global_asm};
 
 use super::{allocate_obj_on_stack, push};
+use crate::coroutine::adjusted_stack_base;
 use crate::stack::{Stack, StackPointer};
 use crate::unwind::{
     asm_may_unwind_root, asm_may_unwind_yield, cfi_reset_args_size_root, cfi_reset_args_size_yield,
@@ -81,6 +82,7 @@ use crate::unwind::{
 use crate::util::EncodedValue;
 
 pub const STACK_ALIGNMENT: usize = 16;
+pub const PARENT_STACK_OFFSET: usize = 16;
 pub const PARENT_LINK_OFFSET: usize = 16;
 pub type StackWord = u64;
 
@@ -194,7 +196,7 @@ extern "C" {
 
 #[inline]
 pub unsafe fn init_stack<T>(stack: &impl Stack, func: InitialFunc<T>, obj: T) -> StackPointer {
-    let mut sp = stack.base().get();
+    let mut sp = adjusted_stack_base(stack).get();
 
     // Initial function.
     push(&mut sp, Some(func as StackWord));
@@ -518,7 +520,7 @@ pub unsafe fn setup_trap_trampoline<T>(
 ) -> TrapHandlerRegs {
     // Preserve the top 16 bytes of the stack since they contain the parent
     // link.
-    let parent_link = stack_base.get() - 16;
+    let parent_link = stack_base.get() - PARENT_LINK_OFFSET;
 
     // Everything below this can be overwritten. Write the object to the stack.
     let mut sp = parent_link;
@@ -551,7 +553,7 @@ pub unsafe fn on_stack(arg: *mut u8, stack: impl Stack, f: StackCallFunc) {
         concat!("bl ", asm_mangle!("stack_call_trampoline")),
         "nop",
         in("$a0") arg,
-        in("$a1") stack.base().get(),
+        in("$a1") adjusted_stack_base(&stack).get(),
         in("$a2") f,
         clobber_abi("C"),
     );

--- a/src/arch/riscv.rs
+++ b/src/arch/riscv.rs
@@ -73,6 +73,7 @@
 use core::arch::{asm, global_asm};
 
 use super::{allocate_obj_on_stack, push};
+use crate::coroutine::adjusted_stack_base;
 use crate::stack::{Stack, StackPointer};
 use crate::unwind::{
     asm_may_unwind_root, asm_may_unwind_yield, cfi_reset_args_size_root, cfi_reset_args_size_yield,
@@ -139,6 +140,7 @@ macro_rules! addi {
 }
 
 pub const STACK_ALIGNMENT: usize = 16;
+pub const PARENT_STACK_OFFSET: usize = x!(8, 16);
 pub const PARENT_LINK_OFFSET: usize = x!(8, 16);
 pub type StackWord = usize;
 
@@ -257,7 +259,7 @@ extern "C" {
 
 #[inline]
 pub unsafe fn init_stack<T>(stack: &impl Stack, func: InitialFunc<T>, obj: T) -> StackPointer {
-    let mut sp = stack.base().get();
+    let mut sp = adjusted_stack_base(stack).get();
 
     // Initial function.
     push(&mut sp, Some(func as StackWord));
@@ -580,7 +582,7 @@ pub unsafe fn setup_trap_trampoline<T>(
 ) -> TrapHandlerRegs {
     // Preserve the top 8/16 bytes of the stack since they contain the parent
     // link.
-    let parent_link = stack_base.get() - x!(8, 16);
+    let parent_link = stack_base.get() - PARENT_LINK_OFFSET;
 
     // Everything below this can be overwritten. Write the object to the stack.
     let mut sp = parent_link;
@@ -615,7 +617,7 @@ pub unsafe fn on_stack(arg: *mut u8, stack: impl Stack, f: StackCallFunc) {
         concat!("call ", asm_mangle!("stack_call_trampoline")),
         "nop",
         in("a0") arg,
-        in("a1") stack.base().get(),
+        in("a1") adjusted_stack_base(&stack).get(),
         in("a2") f,
         clobber_abi("C"),
     )

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -71,6 +71,7 @@
 use core::arch::{asm, global_asm};
 
 use super::{allocate_obj_on_stack, push};
+use crate::coroutine::adjusted_stack_base;
 use crate::stack::{Stack, StackPointer};
 use crate::unwind::{
     asm_may_unwind_root, asm_may_unwind_yield, cfi_reset_args_size_root, cfi_reset_args_size_yield,
@@ -79,7 +80,8 @@ use crate::unwind::{
 use crate::util::EncodedValue;
 
 pub const STACK_ALIGNMENT: usize = 16;
-pub const PARENT_LINK_OFFSET: usize = 0;
+pub const PARENT_STACK_OFFSET: usize = 0;
+pub const PARENT_LINK_OFFSET: usize = 8;
 pub type StackWord = u32;
 
 global_asm!(
@@ -187,7 +189,7 @@ extern "C" {
 
 #[inline]
 pub unsafe fn init_stack<T>(stack: &impl Stack, func: InitialFunc<T>, obj: T) -> StackPointer {
-    let mut sp = stack.base().get();
+    let mut sp = adjusted_stack_base(stack).get();
 
     // Initial function.
     push(&mut sp, Some(func as StackWord));
@@ -506,7 +508,7 @@ pub unsafe fn setup_trap_trampoline<T>(
     handler: TrapHandler<T>,
 ) -> TrapHandlerRegs {
     // Preserve the top 8 bytes of the stack since they contain the parent link.
-    let parent_link = stack_base.get() - 8;
+    let parent_link = stack_base.get() - PARENT_LINK_OFFSET;
 
     // Everything below this can be overwritten. Write the object to the stack.
     let mut sp = parent_link;
@@ -546,7 +548,7 @@ pub unsafe fn on_stack(arg: *mut u8, stack: impl Stack, f: StackCallFunc) {
         concat!("call ", asm_mangle!("stack_call_trampoline")),
         "nop",
         in("ecx") arg,
-        in("edx") stack.base().get(),
+        in("edx") adjusted_stack_base(&stack).get(),
         in("eax") f,
         clobber_abi("fastcall"),
     )

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -5,6 +5,7 @@ use core::mem::{self, ManuallyDrop};
 use core::ptr;
 
 use crate::arch::{self, STACK_ALIGNMENT};
+use crate::sanitizer::SanitizerFiber;
 #[cfg(feature = "default-stack")]
 use crate::stack::DefaultStack;
 #[cfg(windows)]
@@ -40,6 +41,14 @@ impl<Yield, Return> CoroutineResult<Yield, Return> {
             CoroutineResult::Return(val) => Some(val),
         }
     }
+}
+
+/// When using sanitizers, we need to stash the bounds of the parent stack at a
+/// fixed offset from the parent link so that we can inform the sanitizer
+/// runtime of any stack switches.
+#[inline]
+pub(crate) fn adjusted_stack_base(stack: &impl stack::Stack) -> StackPointer {
+    unsafe { StackPointer::new_unchecked(stack.base().get() - mem::size_of::<SanitizerFiber>()) }
 }
 
 /// A coroutine wraps a closure and allows suspending its execution more than
@@ -82,6 +91,12 @@ pub struct Coroutine<Input, Yield, Return, Stack: stack::Stack = DefaultStack> {
     // Function to call to drop the initial state of a coroutine if it has
     // never been resumed.
     drop_fn: unsafe fn(ptr: *mut u8),
+
+    // Data used by sanitizers for tracking stack bounds.
+    //
+    // This is not necessarily the same as `stack.sanitizer_fiber()` if the
+    // coroutine has made further stack switches.
+    sanitizer_fiber: SanitizerFiber,
 
     // We want to be covariant over Yield and Return, and contravariant
     // over Input.
@@ -126,6 +141,7 @@ pub struct Coroutine<Input, Yield, Return, Stack: stack::Stack> {
     stack_ptr: Option<StackPointer>,
     initial_stack_ptr: StackPointer,
     drop_fn: unsafe fn(ptr: *mut u8),
+    sanitizer_fiber: SanitizerFiber,
     marker: PhantomData<fn(Input) -> CoroutineResult<Yield, Return>>,
     marker2: PhantomData<*mut ()>,
 }
@@ -184,6 +200,13 @@ impl<Input, Yield, Return, Stack: stack::Stack> Coroutine<Input, Yield, Return, 
                 // parent link on the stack.
                 let yielder = &*(parent_link as *mut StackPointer as *const Yielder<Input, Yield>);
 
+                // If using sanitizers, store the parent's stack bounds at a
+                // fixed offset from the parent link.
+                unsafe {
+                    *SanitizerFiber::from_parent_link(parent_link) =
+                        SanitizerFiber::finish_switch(ptr::null_mut());
+                }
+
                 // Read the function from the stack.
                 debug_assert_eq!(func as usize % mem::align_of::<F>(), 0);
                 let f = func.read();
@@ -200,7 +223,12 @@ impl<Input, Yield, Return, Stack: stack::Stack> Coroutine<Input, Yield, Return, 
                 };
 
                 // Run the body of the generator, catching any panics.
-                let result = unwind::catch_unwind_at_root(|| f(yielder, input));
+                let result = unwind::catch_unwind_at_root(|| f(&yielder, input));
+
+                // If using sanitizers, restore the parent's stack bounds.
+                unsafe {
+                    (*SanitizerFiber::from_parent_link(parent_link)).start_switch();
+                }
 
                 // Return any caught panics to the parent context.
                 let mut result = ManuallyDrop::new(result);
@@ -218,12 +246,13 @@ impl<Input, Yield, Return, Stack: stack::Stack> Coroutine<Input, Yield, Return, 
             // coroutine_func. Write the given function object to the stack so
             // its address is passed to coroutine_func on the first resume.
             let stack_ptr = arch::init_stack(&stack, coroutine_func::<Input, Yield, Return, F>, f);
-
+            let sanitizer_fiber = stack.sanitizer_fiber();
             Self {
                 stack,
                 stack_ptr: Some(stack_ptr),
                 initial_stack_ptr: stack_ptr,
                 drop_fn: drop_fn::<F>,
+                sanitizer_fiber,
                 marker: PhantomData,
                 marker2: PhantomData,
             }
@@ -274,10 +303,17 @@ impl<Input, Yield, Return, Stack: stack::Stack> Coroutine<Input, Yield, Return, 
         // switch_and_link unwinds.
         self.stack_ptr = None;
 
+        let fake_stack = self.sanitizer_fiber.start_switch();
+
         let mut input = ManuallyDrop::new(input);
-        let (result, stack_ptr) =
-            arch::switch_and_link(util::encode_val(&mut input), stack_ptr, self.stack.base());
+        let (result, stack_ptr) = arch::switch_and_link(
+            util::encode_val(&mut input),
+            stack_ptr,
+            adjusted_stack_base(&self.stack),
+        );
         self.stack_ptr = stack_ptr;
+
+        self.sanitizer_fiber = SanitizerFiber::finish_switch(fake_stack);
 
         // Decode the returned value depending on whether the coroutine
         // terminated.
@@ -315,7 +351,7 @@ impl<Input, Yield, Return, Stack: stack::Stack> Coroutine<Input, Yield, Return, 
         #[cfg(windows)]
         if let Some(stack_ptr) = self.stack_ptr {
             if self.started() {
-                arch::reset_teb_fields_from_suspended(self.stack.base(), stack_ptr);
+                arch::reset_teb_fields_from_suspended(adjusted_stack_base(&self.stack), stack_ptr);
             }
         }
         self.stack_ptr = None;
@@ -354,7 +390,7 @@ impl<Input, Yield, Return, Stack: stack::Stack> Coroutine<Input, Yield, Return, 
         // initial object.
         if !self.started() {
             unsafe {
-                arch::drop_initial_obj(self.stack.base(), stack_ptr, self.drop_fn);
+                arch::drop_initial_obj(adjusted_stack_base(&self.stack), stack_ptr, self.drop_fn);
             }
             self.stack_ptr = None;
             return;
@@ -413,7 +449,7 @@ impl<Input, Yield, Return, Stack: stack::Stack> Coroutine<Input, Yield, Return, 
         self.stack_ptr = None;
 
         let (result, stack_ptr) =
-            arch::switch_and_throw(forced_unwind, stack_ptr, self.stack.base());
+            arch::switch_and_throw(forced_unwind, stack_ptr, adjusted_stack_base(&self.stack));
         self.stack_ptr = stack_ptr;
 
         // Decode the returned value depending on whether the coroutine
@@ -434,6 +470,11 @@ impl<Input, Yield, Return, Stack: stack::Stack> Coroutine<Input, Yield, Return, 
             self.done(),
             "cannot extract stack from an incomplete coroutine"
         );
+
+        // Clear any ASAN poisoning on the stack before it gets re-used.
+        unsafe {
+            self.stack.sanitizer_fiber().unpoison_stack();
+        }
 
         #[cfg(windows)]
         unsafe {
@@ -460,7 +501,7 @@ impl<Input, Yield, Return, Stack: stack::Stack> Coroutine<Input, Yield, Return, 
     /// safety requirements.
     pub fn trap_handler(&self) -> CoroutineTrapHandler<Return> {
         CoroutineTrapHandler {
-            stack_base: self.stack.base(),
+            stack_base: adjusted_stack_base(&self.stack),
             stack_limit: self.stack.limit(),
             marker: PhantomData,
         }
@@ -476,6 +517,11 @@ impl<Input, Yield, Return, Stack: stack::Stack> Drop for Coroutine<Input, Yield,
         });
         self.force_unwind();
         mem::forget(guard);
+
+        // Clear any ASAN poisoning on the stack before it gets re-used.
+        unsafe {
+            self.stack.sanitizer_fiber().unpoison_stack();
+        }
 
         #[cfg(windows)]
         unsafe {
@@ -505,8 +551,19 @@ impl<Input, Yield> Yielder<Input, Yield> {
     /// [`Coroutine::resume`] function is called again.
     pub fn suspend(&self, val: Yield) -> Input {
         unsafe {
+            let parent_link = self as *const Self as *mut StackPointer;
+
+            // The parent's stack bounds are kept at a fixed offset from the
+            // parent link. These are used by the sanitizer runtime.
+            let sanitizer_fiber = &mut *SanitizerFiber::from_parent_link(parent_link);
+            let fake_stack = sanitizer_fiber.start_switch();
+
             let mut val = ManuallyDrop::new(val);
             let result = arch::switch_yield(util::encode_val(&mut val), self.stack_ptr.as_ptr());
+
+            // Save the parent's possibly updated stack bounds after the switch.
+            *sanitizer_fiber = SanitizerFiber::finish_switch(fake_stack);
+
             unwind::maybe_force_unwind(util::decode_val(result))
         }
     }
@@ -532,11 +589,13 @@ impl<Input, Yield> Yielder<Input, Yield> {
     {
         // Get the top of the parent stack.
         let stack_ptr = unsafe {
-            StackPointer::new_unchecked(self.stack_ptr.get().get() - arch::PARENT_LINK_OFFSET)
+            StackPointer::new_unchecked(self.stack_ptr.get().get() - arch::PARENT_STACK_OFFSET)
         };
 
         // Create a virtual stack that starts below the parent stack.
-        let stack = unsafe { ParentStack::new(stack_ptr) };
+        let parent_link = self as *const Self as *mut StackPointer;
+        let sanitizer_fiber = unsafe { *SanitizerFiber::from_parent_link(parent_link) };
+        let stack = unsafe { ParentStack::new(stack_ptr, sanitizer_fiber) };
 
         on_stack(stack, f)
     }
@@ -566,6 +625,8 @@ where
         where
             F: FnOnce() -> R,
         {
+            let sanitizer_fiber = SanitizerFiber::finish_switch(ptr::null_mut());
+
             // Read the function out of the union.
             let data = &mut *(ptr as *mut FuncOrResult<F, R>);
             let func = ManuallyDrop::take(&mut data.func);
@@ -575,6 +636,8 @@ where
 
             // And write the result back to the union.
             data.result = ManuallyDrop::new(result);
+
+            sanitizer_fiber.start_switch();
         }
     }
 
@@ -583,8 +646,13 @@ where
             func: ManuallyDrop::new(f),
         };
 
+        let sanitizer_fiber = stack.sanitizer_fiber();
+        let fake_stack = sanitizer_fiber.start_switch();
+
         // Call the wrapper function on the new stack.
         arch::on_stack(&mut data as *mut _ as *mut u8, stack, wrapper::<F, R>);
+
+        SanitizerFiber::finish_switch(fake_stack);
 
         // Re-throw any panics if one was caught.
         unwind::maybe_resume_unwind(ManuallyDrop::take(&mut data.result))
@@ -604,16 +672,21 @@ struct ParentStack {
     /// stack.
     #[cfg(windows)]
     stack_ptr: StackPointer,
+
+    /// The parent stack's bounds as tracked by the sanitizer runtime. This may
+    /// differ from `stack_base`/`stack_ptr``.
+    sanitizer_fiber: SanitizerFiber,
 }
 
 impl ParentStack {
     #[inline]
-    unsafe fn new(stack_ptr: StackPointer) -> Self {
+    unsafe fn new(stack_ptr: StackPointer, sanitizer_fiber: SanitizerFiber) -> Self {
         let stack_base = StackPointer::new_unchecked(stack_ptr.get() & !(STACK_ALIGNMENT - 1));
         Self {
             stack_base,
             #[cfg(windows)]
             stack_ptr,
+            sanitizer_fiber,
         }
     }
 }
@@ -648,5 +721,10 @@ unsafe impl stack::Stack for ParentStack {
                 guaranteed_stack_bytes,
             );
         }
+    }
+
+    #[inline]
+    fn sanitizer_fiber(&self) -> SanitizerFiber {
+        self.sanitizer_fiber
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,11 +243,12 @@ mod unwind;
 
 mod arch;
 mod coroutine;
+mod sanitizer;
 pub mod stack;
 pub mod trap;
 mod util;
 
-pub use coroutine::*;
+pub use coroutine::{on_stack, Coroutine, CoroutineResult, Yielder};
 
 #[cfg(test)]
 mod tests;

--- a/src/sanitizer.rs
+++ b/src/sanitizer.rs
@@ -1,0 +1,89 @@
+//! Runtime support for address sanitizer.
+
+use crate::stack::StackPointer;
+
+#[cfg(feature = "sanitizer")]
+extern "C" {
+    fn __sanitizer_start_switch_fiber(
+        fake_stack_save: *mut *mut u8,
+        bottom: *const u8,
+        size: usize,
+    );
+    fn __sanitizer_finish_switch_fiber(
+        fake_stack_save: *mut u8,
+        bottom_old: *mut *const u8,
+        size_old: *mut usize,
+    );
+    fn __asan_unpoison_memory_region(addr: *const u8, size: usize);
+}
+
+/// Information about stack bounds which needs to be communicated to the
+/// sanitizer runtime when switching stacks.
+///
+/// This is an empty struct when sanitizer support is not enabled.
+#[derive(Clone, Copy)]
+pub struct SanitizerFiber {
+    #[cfg(feature = "sanitizer")]
+    pub(crate) bottom: *const u8,
+    #[cfg(feature = "sanitizer")]
+    pub(crate) size: usize,
+}
+
+unsafe impl Send for SanitizerFiber {}
+unsafe impl Sync for SanitizerFiber {}
+
+#[cfg(feature = "sanitizer")]
+impl SanitizerFiber {
+    #[inline]
+    pub(crate) unsafe fn start_switch(&self) -> *mut u8 {
+        let mut fake_stack = core::ptr::null_mut();
+        __sanitizer_start_switch_fiber(&mut fake_stack, self.bottom, self.size);
+        fake_stack
+    }
+
+    #[inline]
+    pub(crate) unsafe fn finish_switch(fake_stack: *mut u8) -> Self {
+        let mut bottom = core::ptr::null();
+        let mut size = 0;
+        __sanitizer_finish_switch_fiber(fake_stack, &mut bottom, &mut size);
+        Self { bottom, size }
+    }
+
+    #[inline]
+    pub(crate) unsafe fn from_parent_link(parent_link: *mut StackPointer) -> *mut Self {
+        parent_link.byte_add(crate::arch::PARENT_LINK_OFFSET).cast()
+    }
+
+    #[inline]
+    pub(crate) unsafe fn unpoison_stack(&self) {
+        __asan_unpoison_memory_region(self.bottom, self.size);
+    }
+}
+
+#[cfg(not(feature = "sanitizer"))]
+impl SanitizerFiber {
+    #[inline]
+    pub(crate) unsafe fn start_switch(&self) -> *mut u8 {
+        core::ptr::dangling_mut()
+    }
+
+    #[inline]
+    pub(crate) unsafe fn finish_switch(_fake_stack: *mut u8) -> Self {
+        Self {}
+    }
+
+    #[inline]
+    pub(crate) unsafe fn from_parent_link(_parent_link: *mut StackPointer) -> *mut Self {
+        core::ptr::dangling_mut()
+    }
+
+    #[inline]
+    pub(crate) unsafe fn unpoison_stack(&self) {}
+}
+
+#[inline]
+#[allow(unused_variables)]
+pub(crate) unsafe fn unpoison_stack_range(base: StackPointer, limit: StackPointer) {
+    #[cfg(feature = "sanitizer")]
+    __asan_unpoison_memory_region(limit.get() as *const u8, base.get() - limit.get());
+}

--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -6,6 +6,8 @@
 
 use core::num::NonZeroUsize;
 
+use crate::sanitizer::SanitizerFiber;
+
 pub mod valgrind;
 
 cfg_if::cfg_if! {
@@ -64,6 +66,18 @@ pub unsafe trait Stack {
     /// executing code on the stack.
     #[cfg(windows)]
     fn update_teb_fields(&mut self, stack_limit: usize, guaranteed_stack_bytes: usize);
+
+    /// Internal method to obtain the stack bounds for sanitizer runtime.
+    #[doc(hidden)]
+    #[inline]
+    fn sanitizer_fiber(&self) -> SanitizerFiber {
+        SanitizerFiber {
+            #[cfg(feature = "sanitizer")]
+            bottom: self.limit().get() as *const u8,
+            #[cfg(feature = "sanitizer")]
+            size: self.base().get() - self.limit().get(),
+        }
+    }
 }
 
 /// Fields in the Thread Environment Block (TEB) which must be updated when


### PR DESCRIPTION
Sanitizers like ASAN need to be explicitly told about stack switches to avoid false positives.