### PR TITLE
Use a local label to refer to `stack_init_trampoline_return` in asm

### DIFF
--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -131,9 +131,8 @@ global_asm!(
     "adr lr, 0f",
     "ldr x3, [x1, #8]",
     "br x3",
-    // AArch64 Mach-O does not have a way of representing relocations on an ADR
-    // instruction so we have to use a local label that the assembler can fully
-    // resolve ahead of time.
+    // Use a local label because stack_init_trampoline_return is a global
+    // symbol, which can cause issues with relocations.
     "0:",
     asm_function_alt_entry!("stack_init_trampoline_return"),
     // This BRK is necessary because of our use of .cfi_signal_frame earlier.

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -330,21 +330,18 @@ global_asm!(
     concat!(".movsp ", fp!()),
     // As in the original x86_64 code, hand-write the call operation so that it
     // doesn't push an entry into the CPU's return prediction stack.
-    thumb2!(thumb_symbol_adr!(
-        "lr",
-        asm_mangle!("stack_init_trampoline_return")
-    )),
+    thumb2!(thumb_symbol_adr!("lr", "0f")),
     thumb2!("ldr pc, [r1, #4]"),
-    thumb1!(thumb_symbol_adr!(
-        "r3",
-        asm_mangle!("stack_init_trampoline_return")
-    )),
+    thumb1!(thumb_symbol_adr!("r3", "0f")),
     thumb1!("mov lr, r3"),
     thumb1!("ldr r3, [r1, #4]"),
     thumb1!("bx r3"),
     // The balign here seems to be necessary otherwise LLVM's assembler
     // generates invalid offsets to the label.
     ".balign 4",
+    // Use a local label because stack_init_trampoline_return is a global
+    // symbol, which can cause issues with relocations.
+    "0:",
     thumb_symbol_def!(),
     asm_function_alt_entry!("stack_init_trampoline_return"),
     // This UDF is necessary because of our use of .cfi_signal_frame earlier.

--- a/src/arch/loongarch64.rs
+++ b/src/arch/loongarch64.rs
@@ -136,6 +136,8 @@ global_asm!(
     "la.pcrel $ra, 0f",
     "ld.d $t0, $a1, 8",
     "jr $t0",
+    // Use a local label because stack_init_trampoline_return is a global
+    // symbol, which can cause issues with relocations.
     "0:",
     asm_function_alt_entry!("stack_init_trampoline_return"),
     // This BREAK is necessary because of our use of .cfi_signal_frame earlier.

--- a/src/arch/riscv.rs
+++ b/src/arch/riscv.rs
@@ -196,9 +196,12 @@ global_asm!(
     concat!(".cfi_offset s0, ", xlen_bytes!(-4)),
     // As in the original x86_64 code, hand-write the call operation so that it
     // doesn't push an entry into the CPU's return prediction stack.
-    concat!("lla ra, ", asm_mangle!("stack_init_trampoline_return")),
+    "lla ra, 0f",
     l!("t0", 1, "a1"),
     "jr t0",
+    // Use a local label because stack_init_trampoline_return is a global
+    // symbol, which can cause issues with relocations.
+    "0:",
     asm_function_alt_entry!("stack_init_trampoline_return"),
     // This UNIMP is necessary because of our use of .cfi_signal_frame earlier.
     "unimp",

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -206,11 +206,7 @@ global_asm!(
     // is later executed by a switch_yield() or switch_and_reset() in the
     // initial function. This is the reason why those functions are marked as
     // #[inline(always)].
-    concat!(
-        "lea rcx, [rip + ",
-        asm_mangle!("stack_init_trampoline_return"),
-        "]"
-    ),
+    "lea rcx, [rip + 0f]",
     "push rcx",
     // init_stack() placed the address of the initial function just above the
     // parent link on the stack.
@@ -218,6 +214,9 @@ global_asm!(
     // We don't need to do anything afterwards since the initial function will
     // never return. This is guaranteed by the ! return type.
     //
+    // Use a local label because stack_init_trampoline_return is a global
+    // symbol, which can cause issues with relocations.
+    "0:",
     // Export the return target of the initial trampoline. This is used when
     // setting up a trap handler.
     asm_function_alt_entry!("stack_init_trampoline_return"),

--- a/src/arch/x86_64_windows.rs
+++ b/src/arch/x86_64_windows.rs
@@ -193,13 +193,12 @@ global_asm!(
     "mov rdx, rsp",
     // As in the original x86_64 code, hand-write the call operation so that it
     // doesn't push an entry into the CPU's return prediction stack.
-    concat!(
-        "lea rcx, [rip + ",
-        asm_mangle!("stack_init_trampoline_return"),
-        "]"
-    ),
+    "lea rcx, [rip + 0f]",
     "push rcx",
     "jmp [rsi + 8]",
+    // Use a local label because stack_init_trampoline_return is a global
+    // symbol, which can cause issues with relocations.
+    "0:",
     asm_function_alt_entry!("stack_init_trampoline_return"),
     // The SEH unwinder works by looking at a return target and scanning forward
     // to look for an epilog code sequence. We add an int3 instruction to avoid


### PR DESCRIPTION
This avoids issues with relocations when building as a shared library. Specifically, `stack_init_trampoline_return` being a global symbol means that it could be overriden and must therefore always be accessed via the GOT. Using a local label avoids this issue and allows the use of relative addressing.

Fixes wasmerio/wasmer#5721